### PR TITLE
GH-5 Upgrade flake8-bandit to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ python = "^3.9"
 [tool.poetry.dev-dependencies]
 black = "^21.11b1"
 flake8 = "^4.0.1"
-flake8-bandit = "^2.1.2"
+flake8-bandit = "^3.0.0"
 flake8-bugbear = "^21.9.2"
 flake8-docstrings = "^1.6.0"
 flake8-isort = "^4.1.1"


### PR DESCRIPTION
It contains a fix for a compatibility break in Bandit.